### PR TITLE
Improve TX formatting

### DIFF
--- a/src/components/Data.tsx
+++ b/src/components/Data.tsx
@@ -7,12 +7,14 @@ type DataType = {
 };
 
 function renderAnything(value: unknown): React.ReactNode {
+  if (value === null || value === undefined) {
+    return "-";
+  }
+
   if (
     React.isValidElement(value) ||
     typeof value === "string" ||
     typeof value === "number" ||
-    value === null ||
-    value === undefined ||
     value === false
   ) {
     return value;

--- a/src/components/InnerTransactionCard.tsx
+++ b/src/components/InnerTransactionCard.tsx
@@ -16,6 +16,7 @@ const TX_KIND_ALIASES: Record<string, string> = {
   unbond: "Unbond (Unstake)",
   ibcMsgTransfer: "Unshield over IBC",
   ibcTransparentTransfer: "IBC Transfer",
+  claimRewards: "Claim Staking Rewards",
 };
 
 type WrapperTxData = {

--- a/src/components/InnerTransactionCard.tsx
+++ b/src/components/InnerTransactionCard.tsx
@@ -6,12 +6,22 @@ import { TransactionDetailsData } from "./TransactionDetailsData";
 import { TransactionStatusBadge } from "./TransactionStatusBadge";
 import { decodeHexAscii } from "../utils/transactions";
 
+type WrapperTxData = {
+  kind?: string;
+  feePayer?: string;
+  amountPerGasUnit?: string;
+  gasLimit?: string;
+  feeToken?: string;
+};
+
 type InnerTransactionCardProps = {
   innerTransaction: InnerTransaction;
+  wrapperTxData?: WrapperTxData;
 };
 
 export const InnerTransactionCard = ({
   innerTransaction,
+  wrapperTxData,
 }: InnerTransactionCardProps) => {
   return (
     <Grid
@@ -40,7 +50,16 @@ export const InnerTransactionCard = ({
       />
       <Data title="Kind" content={innerTransaction.kind || "unknown"} />
       <Data title="Memo" content={decodeHexAscii(innerTransaction.memo || "") || "-"} />
-      <TransactionDetailsData details={JSON.parse(innerTransaction.data)} />
+      <TransactionDetailsData
+        details={JSON.parse(innerTransaction.data)}
+        wrapperContext={{
+          kind: innerTransaction.kind,  // This should be the inner tx kind like "unshieldingTransfer"
+          feePayer: wrapperTxData?.feePayer,
+          amountPerGasUnit: wrapperTxData?.amountPerGasUnit,
+          gasLimit: wrapperTxData?.gasLimit,
+          feeToken: wrapperTxData?.feeToken,
+        }}
+      />
     </Grid>
   );
 };

--- a/src/components/InnerTransactionCard.tsx
+++ b/src/components/InnerTransactionCard.tsx
@@ -14,6 +14,8 @@ const TX_KIND_ALIASES: Record<string, string> = {
   revealPk: "Reveal Public Key",
   transparentTransfer: "Transparent Transfer",
   unbond: "Unbond (Unstake)",
+  ibcMsgTransfer: "Unshield over IBC",
+  ibcTransparentTransfer: "IBC Transfer",
 };
 
 type WrapperTxData = {

--- a/src/components/InnerTransactionCard.tsx
+++ b/src/components/InnerTransactionCard.tsx
@@ -1,10 +1,20 @@
-import { Grid } from "@chakra-ui/react";
+import { Grid, Text, Box } from "@chakra-ui/react";
 import type { InnerTransaction } from "../types";
 import { Data } from "./Data";
 import { Hash } from "./Hash";
 import { TransactionDetailsData } from "./TransactionDetailsData";
 import { TransactionStatusBadge } from "./TransactionStatusBadge";
 import { decodeHexAscii } from "../utils/transactions";
+
+// Map of transaction kinds to their display aliases
+const TX_KIND_ALIASES: Record<string, string> = {
+  bond: "Bond (Stake)",
+  unshieldingTransfer: "Unshield",
+  shieldingTransfer: "Shield",
+  revealPk: "Reveal Public Key",
+  transparentTransfer: "Transparent Transfer",
+  unbond: "Unbond (Unstake)",
+};
 
 type WrapperTxData = {
   kind?: string;
@@ -23,10 +33,10 @@ export const InnerTransactionCard = ({
   innerTransaction,
   wrapperTxData,
 }: InnerTransactionCardProps) => {
+  const displayKind = TX_KIND_ALIASES[innerTransaction.kind] || innerTransaction.kind || "unknown";
+
   return (
-    <Grid
-      templateColumns={{ base: "1fr", lg: "1fr 1fr" }}
-      gap={4}
+    <Box
       w="100%"
       py={4}
       px={4}
@@ -35,31 +45,47 @@ export const InnerTransactionCard = ({
       borderLeft="2px solid"
       borderColor="yellow"
       overflow="auto"
+      position="relative"
     >
-      <Data
-        title="Inner TX Hash"
-        content={<Hash hash={innerTransaction.txId} enableCopy={true} />}
-      />
-      <Data
-        title="Exit Code"
-        content={
-          <TransactionStatusBadge
-            exitCode={innerTransaction.exitCode || "unknown"}
-          />
-        }
-      />
-      <Data title="Kind" content={innerTransaction.kind || "unknown"} />
-      <Data title="Memo" content={decodeHexAscii(innerTransaction.memo || "") || "-"} />
-      <TransactionDetailsData
-        details={JSON.parse(innerTransaction.data)}
-        wrapperContext={{
-          kind: innerTransaction.kind,  // This should be the inner tx kind like "unshieldingTransfer"
-          feePayer: wrapperTxData?.feePayer,
-          amountPerGasUnit: wrapperTxData?.amountPerGasUnit,
-          gasLimit: wrapperTxData?.gasLimit,
-          feeToken: wrapperTxData?.feeToken,
-        }}
-      />
-    </Grid>
+      {/* Transaction Kind - Top Left Corner */}
+      <Text
+        color="cyan"
+        fontSize="lg"
+        fontWeight="semibold"
+        mb={4}
+      >
+        {displayKind}
+      </Text>
+
+      <Grid
+        templateColumns={{ base: "1fr", lg: "1fr 1fr" }}
+        gap={4}
+      >
+        <Data
+          title="Inner TX Hash"
+          content={<Hash hash={innerTransaction.txId} enableCopy={true} />}
+        />
+        <Data
+          title="Exit Code"
+          content={
+            <TransactionStatusBadge
+              exitCode={innerTransaction.exitCode || "unknown"}
+            />
+          }
+        />
+        <TransactionDetailsData
+          details={JSON.parse(innerTransaction.data)}
+          wrapperContext={{
+            kind: innerTransaction.kind,  // This should be the inner tx kind like "unshieldingTransfer"
+            feePayer: wrapperTxData?.feePayer,
+            amountPerGasUnit: wrapperTxData?.amountPerGasUnit,
+            gasLimit: wrapperTxData?.gasLimit,
+            feeToken: wrapperTxData?.feeToken,
+          }}
+        />
+        {/* Memo field - placed last */}
+        <Data title="Memo" content={decodeHexAscii(innerTransaction.memo || "") || "-"} />
+      </Grid>
+    </Box>
   );
 };

--- a/src/components/TransactionDetailsData.tsx
+++ b/src/components/TransactionDetailsData.tsx
@@ -219,10 +219,26 @@ const createValueMap = (wrapperContext?: WrapperTxContext): Record<string, Funct
         </VStack>
       );
     },
-    shielded_section_hash: (value: string) => {
+    shielded_section_hash: (value: any) => {
       if (!value || value === null || value === undefined) {
         return <>-</>;
       }
+
+      // Check if value is an array of bytes (numbers)
+      if (Array.isArray(value) && value.every((item: any) => typeof item === 'number' && item >= 0 && item <= 255)) {
+        // Convert byte array to hex string
+        const hexString = value
+          .map((byte: number) => byte.toString(16).padStart(2, '0'))
+          .join('');
+
+        return (
+          <Text fontFamily="mono" fontSize="sm">
+            0x{hexString}
+          </Text>
+        );
+      }
+
+      // For other types, fall back to JSON stringify
       return <>{JSON.stringify(value)}</>;
     },
   };

--- a/src/components/TransactionDetailsData.tsx
+++ b/src/components/TransactionDetailsData.tsx
@@ -1,9 +1,10 @@
 import type { Asset } from "@chain-registry/types";
-import { VStack, HStack, Text, Box } from "@chakra-ui/react";
+import { VStack, HStack, Text, Box, Image } from "@chakra-ui/react";
 import BigNumber from "bignumber.js";
 import { useChainAssetsMap } from "../queries/useChainAssetsMap";
+import { useAllValidators } from "../queries/useAllValidators";
 import { accountUrl, validatorUrl } from "../routes";
-import type { TransactionSource, TransactionTarget } from "../types";
+import type { TransactionSource, TransactionTarget, Validator } from "../types";
 import { shortenHashOrAddress, toDisplayAmount, NAMADA_ADDRESS } from "../utils";
 import { Data } from "./Data";
 import { Hash } from "./Hash";
@@ -32,13 +33,49 @@ type WrapperTxContext = {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 const createValueMap = (wrapperContext?: WrapperTxContext): Record<string, Function | undefined> => {
   const { data: chainAssetsMap } = useChainAssetsMap();
+  const { data: validators } = useAllValidators();
 
   return {
-    validator: (address: string) => (
-      <PageLink to={validatorUrl(address)}>
-        {shortenHashOrAddress(address)}
-      </PageLink>
-    ),
+    validator: (address: string) => {
+      const validator = validators?.find((v: Validator) => v.address === address);
+      return (
+        <PageLink to={validatorUrl(address)}>
+          <HStack gap={2} align="center">
+            <Box
+              width="20px"
+              height="20px"
+              borderRadius="full"
+              overflow="hidden"
+              bg="gray.600"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              flexShrink={0}
+            >
+              {validator?.avatar ? (
+                <Image
+                  src={validator.avatar}
+                  alt={validator.name || "Validator"}
+                  width="20px"
+                  height="20px"
+                  objectFit="cover"
+                  onError={(e) => {
+                    e.currentTarget.style.display = "none";
+                  }}
+                />
+              ) : (
+                <Text fontSize="xs" color="gray.300" fontWeight="medium">
+                  {(validator?.name || "U")[0].toUpperCase()}
+                </Text>
+              )}
+            </Box>
+            <Text>
+              {validator?.name || shortenHashOrAddress(address)}
+            </Text>
+          </HStack>
+        </PageLink>
+      );
+    },
     source: (address: string) => (
       <PageLink to={accountUrl(address)}>
         {shortenHashOrAddress(address)}

--- a/src/components/TransactionDetailsData.tsx
+++ b/src/components/TransactionDetailsData.tsx
@@ -4,13 +4,33 @@ import BigNumber from "bignumber.js";
 import { useChainAssetsMap } from "../queries/useChainAssetsMap";
 import { accountUrl, validatorUrl } from "../routes";
 import type { TransactionSource, TransactionTarget } from "../types";
-import { shortenHashOrAddress, toDisplayAmount } from "../utils";
+import { shortenHashOrAddress, toDisplayAmount, NAMADA_ADDRESS } from "../utils";
 import { Data } from "./Data";
 import { Hash } from "./Hash";
 import { PageLink } from "./PageLink";
 
+const formatAmount = (value: string, asset?: Asset) => {
+  if (asset) {
+    const amount = toDisplayAmount(asset as any, BigNumber(value));
+    return (
+      <span>
+        {amount.toString()} {asset.symbol}
+      </span>
+    );
+  }
+  return <span>{value}</span>;
+};
+
+type WrapperTxContext = {
+  kind?: string;
+  feePayer?: string;
+  amountPerGasUnit?: string;
+  gasLimit?: string;
+  feeToken?: string;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-const valueMap: Record<string, Function | undefined> = {
+const createValueMap = (wrapperContext?: WrapperTxContext): Record<string, Function | undefined> => ({
   validator: (address: string) => (
     <PageLink to={validatorUrl(address)}>
       {shortenHashOrAddress(address)}
@@ -21,17 +41,7 @@ const valueMap: Record<string, Function | undefined> = {
       {shortenHashOrAddress(address)}
     </PageLink>
   ),
-  amount: (value: string, asset?: Asset) => {
-    if (asset) {
-      const amount = toDisplayAmount(asset, BigNumber(value));
-      return (
-        <span>
-          {amount.toString()} {asset.symbol}
-        </span>
-      );
-    }
-    return <span>{value}</span>;
-  },
+  amount: formatAmount,
   owner: (address: string) => (
     <PageLink to={accountUrl(address)}>
       {shortenHashOrAddress(address)}
@@ -55,51 +65,116 @@ const valueMap: Record<string, Function | undefined> = {
               </Box>
               <Text color="gray.400">•</Text>
               <Box>
-                {valueMap.amount?.(amount, chainAssetsMap[token])}
+                {formatAmount(amount, chainAssetsMap[token] as any)}
               </Box>
             </HStack>
             {Object.keys(rest).length > 0 && (
-              <TransactionDetailsData details={rest} />
+              <TransactionDetailsData details={rest} wrapperContext={wrapperContext} />
             )}
           </VStack>
         );
       })}
     </VStack>
   ),
-  // target and sources render the same
-  targets: (array: TransactionTarget[]) => (
-    <VStack align="start" gap={1}>
-      {array.map((target, index) => {
-        const { data: chainAssetsMap } = useChainAssetsMap();
-        const { owner, amount, token, type, ...rest } = target;
-        return (
-          <VStack key={index} align="start" gap={1}>
-            <HStack gap={2} align="center" minW="100%">
-              <Box minW="200px">
-                <PageLink to={accountUrl(owner)}>
-                  {shortenHashOrAddress(owner)}
-                </PageLink>
-              </Box>
-              <Text color="gray.400">•</Text>
-              <Box>
-                {valueMap.amount?.(amount, chainAssetsMap[token])}
-              </Box>
-            </HStack>
-            {Object.keys(rest).length > 0 && (
-              <TransactionDetailsData details={rest} />
-            )}
-          </VStack>
-        );
-      })}
-    </VStack>
-  ),
+  targets: (array: TransactionTarget[]) => {
+    const isUnshieldingTransfer = wrapperContext?.kind === "unshieldingTransfer";
+
+    return (
+      <VStack align="start" gap={1}>
+        {array.map((target, index) => {
+          const { data: chainAssetsMap } = useChainAssetsMap();
+          const { owner, amount, token, type, ...rest } = target;
+
+          // Check if this target matches the fee payment for unshielding transfers
+          let isFeePayment = false;
+          if (isUnshieldingTransfer && wrapperContext) {
+            const matchesFeePayer = owner === wrapperContext.feePayer;
+            const matchesFeeToken = token === wrapperContext.feeToken;
+
+            console.log('Checking fee payment for target:', {
+              index,
+              owner,
+              feePayer: wrapperContext.feePayer,
+              matchesFeePayer,
+              token,
+              feeToken: wrapperContext.feeToken,
+              matchesFeeToken,
+              amount,
+              kind: wrapperContext.kind,
+              isUnshieldingTransfer
+            });
+
+            if (matchesFeePayer && wrapperContext.amountPerGasUnit && wrapperContext.gasLimit) {
+              const calculatedFeeInDisplayUnits = new BigNumber(wrapperContext.amountPerGasUnit)
+                .multipliedBy(new BigNumber(wrapperContext.gasLimit));
+
+              // Convert calculated fee to base units for comparison
+              // For native token, amountPerGasUnit is in display units, so convert back to base units
+              // For other tokens, amountPerGasUnit is already in base units
+              const isNativeToken = token === wrapperContext.feeToken &&
+                token === NAMADA_ADDRESS;
+
+              let calculatedFeeInBaseUnits = calculatedFeeInDisplayUnits;
+              if (isNativeToken && chainAssetsMap[token]) {
+                // Convert from display units back to base units by applying the exponent
+                const asset = chainAssetsMap[token] as any;
+                const displayUnit = asset?.denom_units?.find((unit: any) => unit.denom === asset?.display);
+                if (displayUnit?.exponent) {
+                  calculatedFeeInBaseUnits = calculatedFeeInDisplayUnits.shiftedBy(displayUnit.exponent);
+                }
+              }
+
+              const targetAmount = new BigNumber(amount);
+
+              console.log('Fee calculation comparison:', {
+                targetAmount: targetAmount.toString(),
+                calculatedFeeDisplayUnits: calculatedFeeInDisplayUnits.toString(),
+                calculatedFeeBaseUnits: calculatedFeeInBaseUnits.toString(),
+                amountPerGasUnit: wrapperContext.amountPerGasUnit,
+                gasLimit: wrapperContext.gasLimit,
+                isNativeToken,
+                isEqual: targetAmount.isEqualTo(calculatedFeeInBaseUnits)
+              });
+
+              // Try both exact match and fee token match
+              isFeePayment = targetAmount.isEqualTo(calculatedFeeInBaseUnits) && (matchesFeeToken || !wrapperContext.feeToken);
+            }
+          }
+
+          return (
+            <VStack key={index} align="start" gap={1}>
+              <HStack gap={2} align="center" minW="100%">
+                <Box minW="200px">
+                  <PageLink to={accountUrl(owner)}>
+                    {shortenHashOrAddress(owner)}
+                  </PageLink>
+                </Box>
+                <Text color="gray.400">•</Text>
+                <Box>
+                  {formatAmount(amount, chainAssetsMap[token] as any)}
+                  {isFeePayment && (
+                    <Text as="span" color="gray.400" fontSize="sm" ml={2}>
+                      (Fee Payment)
+                    </Text>
+                  )}
+                </Box>
+              </HStack>
+              {Object.keys(rest).length > 0 && (
+                <TransactionDetailsData details={rest} wrapperContext={wrapperContext} />
+              )}
+            </VStack>
+          );
+        })}
+      </VStack>
+    );
+  },
   shielded_section_hash: (value: string) => {
     if (!value || value === null || value === undefined) {
       return <>-</>;
     }
     return <>{JSON.stringify(value)}</>;
   },
-};
+});
 
 const keyMap = (key: string) => {
   key = key.replace(/_/g, " ");
@@ -132,10 +207,18 @@ const ContentArray = <T,>({
   );
 };
 
-export const TransactionDetailsData = ({ details }: { details: unknown }) => {
+export const TransactionDetailsData = ({
+  details,
+  wrapperContext
+}: {
+  details: unknown;
+  wrapperContext?: WrapperTxContext;
+}) => {
+  const valueMap = createValueMap(wrapperContext);
+
   if (Array.isArray(details)) {
     return details.map((item, index) => (
-      <TransactionDetailsData details={item} key={index} />
+      <TransactionDetailsData details={item} key={index} wrapperContext={wrapperContext} />
     ));
   }
 
@@ -148,7 +231,9 @@ export const TransactionDetailsData = ({ details }: { details: unknown }) => {
           valueMap[key] ? (
             valueMap[key](value)
           ) : Array.isArray(value) ? (
-            <ContentArray array={value} Component={TransactionDetailsData} />
+            <ContentArray array={value} Component={({ details }) => (
+              <TransactionDetailsData details={details} wrapperContext={wrapperContext} />
+            )} />
           ) : (
             value
           )

--- a/src/components/TransactionDetailsData.tsx
+++ b/src/components/TransactionDetailsData.tsx
@@ -94,6 +94,9 @@ const valueMap: Record<string, Function | undefined> = {
     </VStack>
   ),
   shielded_section_hash: (value: string) => {
+    if (!value || value === null || value === undefined) {
+      return <>-</>;
+    }
     return <>{JSON.stringify(value)}</>;
   },
 };

--- a/src/components/TransactionDetailsData.tsx
+++ b/src/components/TransactionDetailsData.tsx
@@ -1,5 +1,5 @@
 import type { Asset } from "@chain-registry/types";
-import { VStack } from "@chakra-ui/react";
+import { VStack, HStack, Text, Box } from "@chakra-ui/react";
 import BigNumber from "bignumber.js";
 import { useChainAssetsMap } from "../queries/useChainAssetsMap";
 import { accountUrl, validatorUrl } from "../routes";
@@ -41,26 +41,58 @@ const valueMap: Record<string, Function | undefined> = {
     return <Hash hash={value} enableCopy={true} />;
   },
   sources: (array: TransactionSource[]) => (
-    <ContentArray
-      array={array}
-      Component={({ details }) => {
+    <VStack align="start" gap={1}>
+      {array.map((source, index) => {
         const { data: chainAssetsMap } = useChainAssetsMap();
-        const { owner, amount, token, ...rest } = details;
+        const { owner, amount, token, type, ...rest } = source;
         return (
-          <>
-            <Data title="Owner" content={valueMap.owner?.(owner)} />
-            <Data
-              title="Amount"
-              content={valueMap.amount?.(amount, chainAssetsMap[token])}
-            />
-            <TransactionDetailsData details={rest} />
-          </>
+          <VStack key={index} align="start" gap={1}>
+            <HStack gap={2} align="center" minW="100%">
+              <Box minW="200px">
+                <PageLink to={accountUrl(owner)}>
+                  {shortenHashOrAddress(owner)}
+                </PageLink>
+              </Box>
+              <Text color="gray.400">•</Text>
+              <Box>
+                {valueMap.amount?.(amount, chainAssetsMap[token])}
+              </Box>
+            </HStack>
+            {Object.keys(rest).length > 0 && (
+              <TransactionDetailsData details={rest} />
+            )}
+          </VStack>
         );
-      }}
-    />
+      })}
+    </VStack>
   ),
   // target and sources render the same
-  targets: (array: TransactionTarget[]) => valueMap.sources?.(array),
+  targets: (array: TransactionTarget[]) => (
+    <VStack align="start" gap={1}>
+      {array.map((target, index) => {
+        const { data: chainAssetsMap } = useChainAssetsMap();
+        const { owner, amount, token, type, ...rest } = target;
+        return (
+          <VStack key={index} align="start" gap={1}>
+            <HStack gap={2} align="center" minW="100%">
+              <Box minW="200px">
+                <PageLink to={accountUrl(owner)}>
+                  {shortenHashOrAddress(owner)}
+                </PageLink>
+              </Box>
+              <Text color="gray.400">•</Text>
+              <Box>
+                {valueMap.amount?.(amount, chainAssetsMap[token])}
+              </Box>
+            </HStack>
+            {Object.keys(rest).length > 0 && (
+              <TransactionDetailsData details={rest} />
+            )}
+          </VStack>
+        );
+      })}
+    </VStack>
+  ),
   shielded_section_hash: (value: string) => {
     return <>{JSON.stringify(value)}</>;
   },

--- a/src/pages/TransactionDetails.tsx
+++ b/src/pages/TransactionDetails.tsx
@@ -90,13 +90,12 @@ export const TransactionDetails = () => {
         </Box>
       </Heading>
       <Grid templateColumns="repeat(auto-fit, minmax(200px, 1fr))" gap={1}>
-        <OverviewCard title="Fee Payer">
-          <AccountLink address={txData?.feePayer || ""} />
+        <OverviewCard title="Status">
+          <TransactionStatusBadge exitCode={txData?.exitCode} />
         </OverviewCard>
-        <OverviewCard title="Gas Limit">
-          {txData?.gasLimit || "-"}
+        <OverviewCard title="Block Height">
+          {txData?.blockHeight || "-"}
         </OverviewCard>
-        <OverviewCard title="Gas Used">{txData?.gasUsed || "-"}</OverviewCard>
         <OverviewCard title="Fee Paid">
           {txData?.amountPerGasUnit && txData?.gasLimit && chainAssetsMap
             ? (() => {
@@ -115,14 +114,15 @@ export const TransactionDetails = () => {
             })()
             : "-"}
         </OverviewCard>
+        <OverviewCard title="Fee Payer">
+          <AccountLink address={txData?.feePayer || ""} />
+        </OverviewCard>
+        <OverviewCard title="Gas Limit">
+          {txData?.gasLimit || "-"}
+        </OverviewCard>
+        <OverviewCard title="Gas Used">{txData?.gasUsed || "-"}</OverviewCard>
         <OverviewCard title="MASP Fee">
           {txData?.maspFeePayment?.[1]?.sources?.[0]?.amount || "-"}
-        </OverviewCard>
-        <OverviewCard title="Block Height">
-          {txData?.blockHeight || "-"}
-        </OverviewCard>
-        <OverviewCard title="Status">
-          <TransactionStatusBadge exitCode={txData?.exitCode} />
         </OverviewCard>
         <OverviewCard title="Atomic">
           {txData?.atomic === "true" ? "Yes" : "No"}

--- a/src/pages/TransactionDetails.tsx
+++ b/src/pages/TransactionDetails.tsx
@@ -121,9 +121,6 @@ export const TransactionDetails = () => {
           {txData?.gasLimit || "-"}
         </OverviewCard>
         <OverviewCard title="Gas Used">{txData?.gasUsed || "-"}</OverviewCard>
-        <OverviewCard title="MASP Fee">
-          {txData?.maspFeePayment?.[1]?.sources?.[0]?.amount || "-"}
-        </OverviewCard>
         <OverviewCard title="Atomic">
           {txData?.atomic === "true" ? "Yes" : "No"}
         </OverviewCard>

--- a/src/pages/TransactionDetails.tsx
+++ b/src/pages/TransactionDetails.tsx
@@ -94,9 +94,9 @@ export const TransactionDetails = () => {
           <AccountLink address={txData?.feePayer || ""} />
         </OverviewCard>
         <OverviewCard title="Gas Limit">
-          {txData?.gasLimit || "N/A"}
+          {txData?.gasLimit || "-"}
         </OverviewCard>
-        <OverviewCard title="Gas Used">{txData?.gasUsed || "N/A"}</OverviewCard>
+        <OverviewCard title="Gas Used">{txData?.gasUsed || "-"}</OverviewCard>
         <OverviewCard title="Fee Paid">
           {txData?.amountPerGasUnit && txData?.gasLimit && chainAssetsMap
             ? (() => {
@@ -113,13 +113,13 @@ export const TransactionDetails = () => {
               }
               return `${rawFeeAmount.toFormat()} NAM`;
             })()
-            : "N/A"}
+            : "-"}
         </OverviewCard>
         <OverviewCard title="MASP Fee">
-          {txData?.maspFeePayment?.[1]?.sources?.[0]?.amount || "N/A"}
+          {txData?.maspFeePayment?.[1]?.sources?.[0]?.amount || "-"}
         </OverviewCard>
         <OverviewCard title="Block Height">
-          {txData?.blockHeight || "N/A"}
+          {txData?.blockHeight || "-"}
         </OverviewCard>
         <OverviewCard title="Status">
           <TransactionStatusBadge exitCode={txData?.exitCode} />

--- a/src/pages/TransactionDetails.tsx
+++ b/src/pages/TransactionDetails.tsx
@@ -140,6 +140,13 @@ export const TransactionDetails = () => {
                 <InnerTransactionCard
                   key={innerTransaction.txId || `inner-${index}`}
                   innerTransaction={innerTransaction}
+                  wrapperTxData={{
+                    kind: innerTransaction.kind,
+                    feePayer: txData.feePayer,
+                    amountPerGasUnit: txData.amountPerGasUnit,
+                    gasLimit: txData.gasLimit,
+                    feeToken: txData.feeToken,
+                  }}
                 />
               ),
             )}


### PR DESCRIPTION
Various improvements to the formatting for transactions pages. Consider some before and after examples.

Unshielding before: 
<img width="1626" height="835" alt="image" src="https://github.com/user-attachments/assets/dd85ebb4-5a2e-4879-8200-2551f30d634e" />

Unshielding after: 
<img width="1521" height="483" alt="image" src="https://github.com/user-attachments/assets/566d12d9-bf2f-48cd-9ecf-9b78f670966f" />

Batch transparent transfer before: 
<img width="1488" height="863" alt="image" src="https://github.com/user-attachments/assets/f3552946-836c-461d-8a7e-c6225120c056" />


Batch transparent transfer after: 
<img width="1522" height="757" alt="image" src="https://github.com/user-attachments/assets/b8adff71-e044-4b19-b9db-fefa6bdaa831" />
