### PR TITLE
fix/osmosis usdc asset lookup

### DIFF
--- a/src/queries/useOsmosisPrices.ts
+++ b/src/queries/useOsmosisPrices.ts
@@ -42,7 +42,7 @@ export const useOsmosisPrices = (refreshSecs: number = 30) => {
       const osmosisAssets = osmosisAssetsQuery.data;
 
       // Find USDC base from osmosis assets
-      const usdcAsset = osmosisAssets.find(asset => asset.symbol === "USDC");
+      const usdcAsset = osmosisAssets.find(asset => asset.coingecko_id === "usd-coin");
       if (!usdcAsset) {
         throw new Error("USDC asset not found in Osmosis assets");
       }


### PR DESCRIPTION
since osmosis has more than one asset in its registry with symbol "USDC", use the coingecko_id instead to find the correct one (from noble) when looking up the prices